### PR TITLE
Prepare Puppet modules and manifest prior to provisioning with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /bundle/
 /vendor/gems/
 
+# Librarian-Puppet
+/.librarian/
+/.tmp/
+
 # Vagrant
 .vagrant
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
-  - 2.0.0
 
 install: bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: ruby
 
 rvm:
-  - 1.9.2
+  - 1.8.7
   - 1.9.3
+  - 2.0.0
 
 install: bundle install
 
-script: bundle exec rake test
+script: bundle exec rake travis
 
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org/'
 
+gem 'librarian-puppet'
 gem 'puppet',                 '~> 2.7'
 gem 'puppet-lint',            '~> 0.3'
 gem 'puppetlabs_spec_helper', '~> 0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,10 @@ GEM
   specs:
     diff-lcs (1.2.1)
     facter (1.6.18)
+    json (1.7.7)
+    librarian-puppet (0.9.9)
+      json
+      thor (~> 0.15)
     metaclass (0.0.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -25,11 +29,13 @@ GEM
     rspec-mocks (2.13.0)
     rspec-puppet (0.1.6)
       rspec
+    thor (0.18.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  librarian-puppet
   puppet (~> 2.7)
   puppet-lint (~> 0.3)
   puppetlabs_spec_helper (~> 0.4)

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,3 @@
+# vi: set ft=ruby :
+
+mod "beanstalkd", :path => "."

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,0 +1,8 @@
+PATH
+  remote: .
+  specs:
+    beanstalkd (0.0.1)
+
+DEPENDENCIES
+  beanstalkd (>= 0)
+

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ namespace :vagrant do
                              File.basename(File.dirname(__FILE__)).
                              sub(/^puppet-/, ''))
   FIXTURES_PATH  = ENV.fetch('FIXTURES_PATH',
-                             File.join(ENV['TMPDIR'], 'fixtures'))
+                             File.join(ENV.fetch('TMPDIR', '/tmp'), 'fixtures'))
   MODULES_PATH   = File.join(FIXTURES_PATH, 'modules')
   MANIFESTS_PATH = File.join(FIXTURES_PATH, 'manifests')
   MANIFEST_FILE  = 'init.pp'

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,51 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 desc 'Run all tests'
 task :test => [:lint, :spec]
+
+namespace :vagrant do
+  MODULE_NAME    = ENV.fetch('MODULE_NAME',
+                             File.basename(File.dirname(__FILE__)).
+                             sub(/^puppet-/, ''))
+  FIXTURES_PATH  = ENV.fetch('FIXTURES_PATH',
+                             File.join(ENV['TMPDIR'], 'fixtures'))
+  MODULES_PATH   = File.join(FIXTURES_PATH, 'modules')
+  MANIFESTS_PATH = File.join(FIXTURES_PATH, 'manifests')
+  MANIFEST_FILE  = 'init.pp'
+
+  task :export_vars do
+    # Export settings to Vagrantfile.
+    ENV['MODULES_PATH']   = MODULES_PATH
+    ENV['MANIFESTS_PATH'] = MANIFESTS_PATH
+    ENV['MANIFEST_FILE']  = MANIFEST_FILE
+  end
+
+  task :prepare_modules do
+    # Install module dependencies as specified in Puppetfile.
+    sh 'librarian-puppet', 'install', '--path', MODULES_PATH
+  end
+
+  task :prepare_manifest do
+    # Write manifest file as entry point for testing.
+    mkdir_p MANIFESTS_PATH
+    open(File.join(MANIFESTS_PATH, MANIFEST_FILE), 'w') do |f|
+      f.write "include #{MODULE_NAME}\n"
+    end
+  end
+
+  task :provision => [:prepare_modules, :prepare_manifest, :export_vars] do
+    # Provision VM depending on its state.
+    case `vagrant status`
+    when /The VM is running/ then ['provision']
+    when /To resume this VM/ then ['up', 'provision']
+    else ['up']
+    end.each { |cmd| sh 'vagrant', cmd }
+  end
+
+  task :halt => :export_vars do
+    sh 'vagrant', 'halt', '--force'
+  end
+
+  task :destroy => :export_vars do
+    sh 'vagrant', 'destroy', '--force'
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,13 +5,10 @@ Vagrant::Config.run do |config|
   config.vm.box_url = 'https://jimdo-vagrant-boxes.s3.amazonaws.com/jimdo-debian-6.0.7.box'
   config.vm.host_name = 'skeleton-debian'
 
-  # FIXME we can bind the root github folder to /etc/puppet/modules/... this way,
-  #       but dependencies won't be handled.
-  config.vm.share_folder('beanstalk_module', '/etc/puppet/modules/beanstalkd', '.')
-
   config.vm.provision :puppet do |puppet|
-    puppet.manifests_path = 'manifests'
-    puppet.manifest_file  = 'init.pp'
-    puppet.options = '--verbose --debug'
+    puppet.module_path    = ENV.fetch('MODULES_PATH', 'modules')
+    puppet.manifests_path = ENV.fetch('MANIFESTS_PATH', 'manifests')
+    puppet.manifest_file  = ENV.fetch('MANIFEST_FILE', 'init.pp')
+    puppet.options        = '--verbose --debug'
   end
 end


### PR DESCRIPTION
@zined Here we go.

This is a prototype which incorporates the work I've been doing in https://github.com/Jimdo/puppet-skeleton/pull/1

Running `rake vagrant:provison` will set up the Puppet modules with Librarian-Puppet before provisioning with Vagrant. You can add arbitrary dependencies to `Puppetfile`.

(The generation of the manifest is a bit hacky, but should do for now.)

Looking forward to your feedback. :)
